### PR TITLE
bugfix: make sure nframes set before ops.npy is saved

### DIFF
--- a/gists/save_as_bin.py
+++ b/gists/save_as_bin.py
@@ -17,7 +17,7 @@ from pprint import pprint
 if __name__ == "__main__":
     raw = Path(r"D://demo//raw")
     test_scan = mbo.read_scan(raw)
-    savedir = r"D://demo//assembled"
+    savedir = r"D://demo//assembled3"
     mbo.save_as(test_scan, savedir, ext=".tiff", overwrite=True)
     files = mbo.get_files(savedir, 'tif')
     metadata = mbo.get_metadata(files[0])

--- a/mbo_utilities/assembly.py
+++ b/mbo_utilities/assembly.py
@@ -427,20 +427,25 @@ def _write_tiff(
         if filename.exists() and overwrite:
             filename.unlink()
         _write_tiff._writers[filename] = TiffWriter(filename, bigtiff=True)
-        _write_tiff._first_write = True
+
+        _write_tiff._first_write = {filename: True}
+        # _write_tiff._first_write = True
     else:
-        _write_tiff._first_write = False
+        # _write_tiff._first_write = False
+        _write_tiff._first_write = {filename: False}
 
     writer = _write_tiff._writers[filename]
+    is_first = _write_tiff._first_write.get(filename, False)
 
     for frame in data:
         writer.write(
             frame,
             contiguous=True,
             photometric="minisblack",
-            metadata=metadata if _write_tiff._first_write else None,
+            metadata=metadata if is_first else None,
         )
-        _write_tiff._first_write = False
+        _write_tiff._first_write[filename] = False
+        # _write_tiff._first_write = False
 
 
 def _write_zarr(


### PR DESCRIPTION
Fixes bug where ops.npy is saved for suite2p processing, but this version does not include the updated number of frames as decided by `mbo.save_as` parameters.