### PR TITLE
bugfix multi-selection install, better post-install instructions

### DIFF
--- a/docs/dev/array_dimension_spec.md
+++ b/docs/dev/array_dimension_spec.md
@@ -1,0 +1,251 @@
+# array dimension specification
+
+all array types in mbo_utilities use a fixed 5D layout: **TCZYX**
+
+```
+T - time (frames, volumes, timepoints)
+C - channels (color channels, camera views)
+Z - z-planes (depth, beamlets, z-slices)
+Y - height (spatial)
+X - width (spatial)
+```
+
+singleton dimensions are kept, never squeezed. a single-plane grayscale
+timeseries has shape `(T, 1, 1, Y, X)`, not `(T, Y, X)`.
+
+## why
+
+the previous system had 3D, 4D, or 5D arrays depending on array type and
+runtime state. writers branched on ndim with hardcoded index assumptions.
+every branch was a bug surface. every squeeze erased dimension identity.
+
+with always-5D:
+- `shape[2]` is always Z. no guessing, no `_get_num_planes()` heuristics.
+- writers have one code path. no ndim checks, no squeeze, no np.newaxis.
+- `dims` is a constant, not computed per-instance.
+- consistent with OME-NGFF 0.5, bioio/aicsimageio, and napari conventions.
+
+## protocol
+
+```python
+DIMS = ("T", "C", "Z", "Y", "X")
+
+class ArrayProtocol:
+    shape: tuple[int, int, int, int, int]  # always length 5
+    dims = DIMS                             # constant
+    ndim = 5                                # constant
+    dtype: np.dtype
+
+    @property
+    def nt(self) -> int: return self.shape[0]
+    @property
+    def nc(self) -> int: return self.shape[1]
+    @property
+    def nz(self) -> int: return self.shape[2]
+    @property
+    def ny(self) -> int: return self.shape[3]
+    @property
+    def nx(self) -> int: return self.shape[4]
+```
+
+`__getitem__` follows standard numpy conventions: integer indices squeeze
+their axis, slices keep it. the array object is always 5D. numpy arrays
+returned from indexing follow normal numpy rules.
+
+## dimension mapping per array type
+
+| array type | T | C | Z | Y | X |
+|---|---|---|---|---|---|
+| LBMArray | timepoints | color channels (1-2) | beamlets | height | width |
+| PiezoArray | volumes | 1 | z-slices | height | width |
+| SinglePlaneArray | timepoints | color channels | 1 | height | width |
+| TiffArray (volume) | timepoints | color channels | planes | height | width |
+| TiffArray (single) | timepoints | 1 | 1 | height | width |
+| ZarrArray | timepoints | 1 | planes | height | width |
+| Suite2pArray | timepoints | 1 | planes or 1 | height | width |
+| BinArray | timepoints | 1 | 1 | height | width |
+| IsoviewArray | timepoints | views (cameras) | depth | height | width |
+| LBMPiezoArray | 1 | 1 | z-planes | height | width |
+| H5Array | varies | varies | varies | height | width |
+| NumpyArray | varies | varies | varies | height | width |
+
+semantic differences (volumes vs timepoints, views vs channels, beamlets
+vs z-planes) are display labels, not structural differences. structure is
+always TCZYX.
+
+## what this replaces
+
+### removed patterns
+
+- **ndim branching in writers**: `if ndim == 5 ... elif ndim == 4 ... elif ndim == 3`
+  replaced by one code path that always handles 5D.
+
+- **squeeze operations**: `chunk.squeeze(axis=1)` in `_write_plane`, `_write_bin`,
+  `_write_npy`. these assumed axis 1 was Z without checking. removed entirely.
+
+- **np.newaxis insertions**: `chunk[:, np.newaxis, :, :]` to promote 3D to 4D.
+  unnecessary when input is always 5D.
+
+- **DEFAULT_DIMS mapping**: `{2: ("Y","X"), 3: ("T","Y","X"), 4: ("T","Z","Y","X"), ...}`.
+  replaced by the single constant `DIMS`.
+
+- **DimensionSpecMixin / DimLabels complexity**: computed dims per-instance based on
+  ndim and array type. replaced by a constant.
+
+- **descriptive dim labels**: `("timepoints", "z-planes", "Y", "X")`. structure uses
+  canonical `DIMS`. gui display labels are a separate concern (e.g. `dim_display_names`
+  property for slider widgets).
+
+- **`_ChannelView` wrapper**: wrapped 5D as 4D for suite2p. replaced by direct
+  indexing: `arr[:, channel, :, :, :]`.
+
+- **`_get_num_planes()` heuristics** (lbm_suite2p_python): checked `num_planes`,
+  then `num_channels`, then `shape[1]`. replaced by `arr.nz` or `arr.shape[2]`.
+
+- **`ndim` vs `len(shape)` inconsistency**: ScanImageArray had ndim returning
+  metadata-derived value while shape returned actual shape. with always-5D,
+  both are always 5.
+
+### hardcoded index assumptions removed
+
+these positions were assumed by ndim without validation:
+
+| location | assumption | failure mode |
+|---|---|---|
+| `_write_plane:497` | 5D index as `[t, c, z, y, x]` | TZCYX data |
+| `_write_plane:504` | 4D index as `[t, z, y, x]` | TCYX data |
+| `_write_plane:528` | `shape[1]==1` is Z | could be C=1 |
+| `_write_volumetric_tiff:1211` | 5D input is TCZYX | TZCYX input |
+| `_imwrite_base:430` | 5D `shape[2]` is Z | TZCYX |
+| `_imwrite_base:434` | 4D `shape[1]` is Z | TCYX |
+| `read_chunk:579` | 5D index as `[t, c, z, y, x]` | non-TCZYX order |
+| `_get_num_planes:48` | 4D `shape[1]` is Z | TCYX |
+
+with always-5D TCZYX, none of these need conditional logic. Z is always
+`shape[2]`, C is always `shape[1]`, T is always `shape[0]`.
+
+## writer behavior
+
+### _write_volumetric_tiff
+
+input is always 5D TCZYX. transpose to TZCYX for ImageJ:
+
+```python
+chunk_data = chunk_data.transpose(0, 2, 1, 3, 4)  # always, no ndim check
+```
+
+ImageJ TIFF page ordering is TZCYX: `page = t*(Z*C) + z*C + c`.
+
+### _write_plane (bin/h5/npy per-plane writer)
+
+caller extracts the 3D slice before calling:
+
+```python
+plane_data = data[:, channel_index, plane_index, :, :]  # always valid
+_write_plane(plane_data, ...)  # receives (T, Y, X)
+```
+
+no plane_index or channel_index params needed on `_write_plane` itself.
+
+### _write_volumetric_zarr
+
+input is always 5D. store as 5D zarr with OME-NGFF axes metadata.
+
+### ArraySlicing
+
+always has T, C, Z selections. no conditional dimension detection.
+`read_chunk` always indexes as `arr[t_sel, c_sel, z_sel, :, :]`.
+
+## lbm_suite2p_python changes
+
+### pipeline()
+
+```python
+# before
+if arr.ndim == 4 and not hasattr(arr, "num_planes"):
+    is_volumetric = True
+elif arr.ndim == 3:
+    is_volumetric = False
+
+# after
+is_volumetric = arr.nz > 1
+```
+
+### run_volume()
+
+```python
+# before
+num_planes = _get_num_planes(input_arr)  # heuristic chain
+
+# after
+num_planes = input_arr.nz
+```
+
+### run_plane()
+
+```python
+# before
+write_planes = [plane] if file.ndim >= 4 else None
+imwrite(file, ..., planes=write_planes)
+
+# after
+plane_data = arr[:, 0, plane_idx, :, :]  # 3D (T, Y, X) for suite2p binary
+```
+
+### _compute_projection()
+
+```python
+# before
+if ndim == 4:
+    data = arr[:, plane_idx, :, :]
+elif ndim == 3:
+    data = arr[:]
+else:
+    raise ValueError(...)
+
+# after
+data = arr[:, 0, plane_idx, :, :]  # always valid
+```
+
+## migration
+
+### phase 1: add 5D accessors alongside existing shape
+
+add `nt`, `nc`, `nz`, `ny`, `nx` properties to all array types. add a
+`shape5d` property that returns the 5D shape. validate these match the
+existing shape for every array type via tests. this breaks nothing.
+
+### phase 2: switch shape to always 5D
+
+change every array's `shape` property to return 5D with singletons.
+update `ndim` to always return 5. update `dims` to always return
+`("T", "C", "Z", "Y", "X")`. update writers to drop all ndim branching.
+update lbm_suite2p_python to use `arr.nz` etc.
+
+### phase 3: delete dead code
+
+remove DimLabels complexity, squeeze operations, DEFAULT_DIMS mapping,
+_ChannelView, ndim branching, _get_num_planes heuristics, descriptive
+dim label overrides.
+
+## design decisions
+
+**why not xarray?** adds a heavy dependency and serialization complexity
+for lazy TIFF readers. the benefit of named dims is fully captured by a
+fixed 5D layout.
+
+**why not configurable dimension order?** the whole point is one order.
+making it configurable reintroduces the current problem.
+
+**why not keep backwards-compatible 4D shape?** two code paths forever
+is worse than a clean break. this is a research library, not a public API.
+
+**why TCZYX and not TZCYX?** TCZYX matches OME-NGFF 0.5 and bioio.
+ImageJ uses TZCYX page ordering, but that's a serialization detail
+handled by the writer transpose. internal representation follows the
+standard.
+
+**what about `__getitem__` returning variable ndim?** this is standard
+numpy behavior. `arr[0]` squeezes T, returning 4D `(C, Z, Y, X)`.
+`arr[0, 0, 0]` returns 2D `(Y, X)`. the array *object* is always 5D.
+numpy arrays from indexing follow normal rules. users expect this.

--- a/mbo_utilities/_writers.py
+++ b/mbo_utilities/_writers.py
@@ -1186,6 +1186,15 @@ def _write_volumetric_tiff(
         pbar = None
         if show_progress:
             total_pages = n_frames * n_planes * n_channels
+            parts = []
+            if n_frames > 1:
+                parts.append(f"{n_frames} frames")
+            if n_planes > 1:
+                parts.append(f"{n_planes} planes")
+            if n_channels > 1:
+                parts.append(f"{n_channels} channels")
+            if len(parts) > 1:
+                tqdm.write(f"  {' x '.join(parts)} = {total_pages} pages")
             pbar = tqdm(total=total_pages, desc="Writing TIFF", unit="pg")
 
         # get z-plane indices being written (0-based)

--- a/mbo_utilities/arrays/_base.py
+++ b/mbo_utilities/arrays/_base.py
@@ -634,7 +634,7 @@ class TiffReaderMixin:
             data=self,
             histogram_widget=histogram_widget,
             figure_kwargs=figure_kwargs,
-            graphic_kwargs={"vmin": self.vmin, "vmax": self.vmax},
+            graphic_kwargs={"vmin": self.vmin, "vmax": self.vmax, "cmap": "gnuplot2"},
             window_funcs=window_funcs,
         )
 

--- a/mbo_utilities/arrays/_base.py
+++ b/mbo_utilities/arrays/_base.py
@@ -634,7 +634,8 @@ class TiffReaderMixin:
             data=self,
             histogram_widget=histogram_widget,
             figure_kwargs=figure_kwargs,
-            graphic_kwargs={"vmin": self.vmin, "vmax": self.vmax, "cmap": "gnuplot2"},
+            cmap="gnuplot2",
+            graphic_kwargs={"vmin": self.vmin, "vmax": self.vmax},
             window_funcs=window_funcs,
         )
 

--- a/mbo_utilities/gui/run_gui.py
+++ b/mbo_utilities/gui/run_gui.py
@@ -482,7 +482,7 @@ def _create_image_widget(data_array, widget: bool = True):
             window_sizes=window_sizes,
             histogram_widget=True,
             figure_kwargs=figure_kwargs,
-            graphic_kwargs={"vmin": -100, "vmax": 4000},
+            graphic_kwargs={"vmin": -100, "vmax": 4000, "cmap": "gnuplot2"},
         )
     else:
         iw = fpl.ImageWidget(
@@ -492,7 +492,7 @@ def _create_image_widget(data_array, widget: bool = True):
             window_sizes=window_sizes,
             histogram_widget=True,
             figure_kwargs=figure_kwargs,
-            graphic_kwargs={"vmin": -100, "vmax": 4000},
+            graphic_kwargs={"vmin": -100, "vmax": 4000, "cmap": "gnuplot2"},
         )
 
     iw.show()

--- a/mbo_utilities/gui/run_gui.py
+++ b/mbo_utilities/gui/run_gui.py
@@ -480,9 +480,10 @@ def _create_image_widget(data_array, widget: bool = True):
             slider_dim_names=slider_dim_names,
             window_funcs=window_funcs,
             window_sizes=window_sizes,
+            cmap="gnuplot2",
             histogram_widget=True,
             figure_kwargs=figure_kwargs,
-            graphic_kwargs={"vmin": -100, "vmax": 4000, "cmap": "gnuplot2"},
+            graphic_kwargs={"vmin": -100, "vmax": 4000},
         )
     else:
         iw = fpl.ImageWidget(
@@ -490,9 +491,10 @@ def _create_image_widget(data_array, widget: bool = True):
             slider_dim_names=slider_dim_names,
             window_funcs=window_funcs,
             window_sizes=window_sizes,
+            cmap="gnuplot2",
             histogram_widget=True,
             figure_kwargs=figure_kwargs,
-            graphic_kwargs={"vmin": -100, "vmax": 4000, "cmap": "gnuplot2"},
+            graphic_kwargs={"vmin": -100, "vmax": 4000},
         )
 
     iw.show()

--- a/mbo_utilities/metadata/io.py
+++ b/mbo_utilities/metadata/io.py
@@ -495,10 +495,12 @@ def get_metadata_batch(file_paths: list | tuple):
     # Count frames for all files
     frames_per_file = [
         query_tiff_pages(fp) // nchannels
-        for fp in tqdm(file_paths, desc="Counting frames", disable=len(file_paths) < 2)
+        for fp in tqdm(file_paths, desc="Counting frames", unit="file", disable=len(file_paths) < 2)
     ]
 
     total_frames = sum(frames_per_file)
+    if len(file_paths) >= 2:
+        tqdm.write(f"  {total_frames} frames across {len(file_paths)} files")
     return metadata | {
         "num_timepoints": total_frames,
         "nframes": total_frames,  # suite2p alias

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -687,27 +687,44 @@ try:
     from importlib.metadata import version, distribution
     v = version('mbo_utilities')
     d = distribution('mbo_utilities')
+    import json, glob
+    from pathlib import Path
     direct_url = None
-    try:
-        import json
-        du_files = [f for f in (d.files or []) if str(f).endswith('direct_url.json')]
-        if du_files:
-            du_path = d.locate_file(du_files[0])
-            if du_path.exists():
-                direct_url = json.loads(du_path.read_text())
-    except Exception:
-        pass
+    dist_path = str(Path(d._path).resolve())
+    is_egg = '.egg-info' in dist_path
+    # egg-info from editable installs can shadow dist-info in site-packages.
+    # check site-packages for a dist-info with direct_url.json first.
+    if is_egg and 'site-packages' not in dist_path:
+        sp_dirs = [p for p in sys.path if 'site-packages' in p]
+        for sp in sp_dirs:
+            for di in glob.glob(str(Path(sp) / 'mbo_utilities-*.dist-info')):
+                du_file = Path(di) / 'direct_url.json'
+                if du_file.exists():
+                    direct_url = json.loads(du_file.read_text())
+                    is_egg = False
+                    break
+            if direct_url:
+                break
+    if not direct_url:
+        try:
+            du_files = [f for f in (d.files or []) if str(f).endswith('direct_url.json')]
+            if du_files:
+                du_path = d.locate_file(du_files[0])
+                if du_path.exists():
+                    direct_url = json.loads(du_path.read_text())
+        except Exception:
+            pass
     if direct_url and 'vcs_info' in direct_url:
         vcs = direct_url['vcs_info']
         commit = vcs.get('commit_id', 'unknown')[:8]
         branch = vcs.get('requested_revision', 'unknown')
         print(f'{v}|git|{branch}|{commit}')
     elif direct_url and direct_url.get('dir_info', {}).get('editable', False):
-        url = direct_url.get('url', '')
-        print(f'{v}|editable|{url}|')
+        print(f'{v}|editable||')
+    elif is_egg and 'site-packages' not in dist_path:
+        print(f'{v}|editable||')
     elif direct_url:
-        url = direct_url.get('url', '')
-        print(f'{v}|local|{url}|')
+        print(f'{v}|local||')
     else:
         print(f'{v}|pypi||')
 except Exception as e:

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -466,11 +466,19 @@ function Show-OptionalDependencies {
     do {
         $choice = Read-Host "Select option (1-5, or comma-separated like 1,3)"
         $valid = $choice -match '^[1-5](,[1-5])*$'
-        if (-not $valid) { Write-Warn "Invalid selection. Enter 1-5 or comma-separated." }
+        if (-not $valid) {
+            Write-Warn "Invalid selection. Enter 1-5 or comma-separated."
+            continue
+        }
+        $choices = $choice -split ',' | ForEach-Object { $_.Trim() } | Select-Object -Unique
+        # reject contradictory combos: 4 or 5 with other selections
+        if ($choices.Count -gt 1 -and ($choices -contains "4" -or $choices -contains "5")) {
+            Write-Warn "Options 4 (All) and 5 (None) cannot be combined with other selections."
+            $valid = $false
+        }
     } while (-not $valid)
 
     $extras = @()
-    $choices = $choice -split ',' | ForEach-Object { $_.Trim() } | Select-Object -Unique
 
     :parseLoop foreach ($c in $choices) {
         switch ($c) {
@@ -534,23 +542,7 @@ function Install-MboTool {
     Write-Host ""
     Write-Info "Installing mbo CLI tool via uv tool install..."
 
-    # build spec with extras
-    # For git URLs: "mbo_utilities @ git+..." -> "mbo_utilities[extras] @ git+..."
-    # For PyPI: "mbo_utilities" -> "mbo_utilities[extras]"
-    if ($Extras.Count -gt 0) {
-        $extrasStr = "[" + ($Extras -join ',') + "]"
-        if ($Spec -match '^([^\s@]+)(\s*@\s*.*)$') {
-            # Git URL format: insert extras after package name, before @ URL
-            $fullSpec = $matches[1] + $extrasStr + $matches[2]
-        }
-        else {
-            # PyPI format: just append extras
-            $fullSpec = "$Spec$extrasStr"
-        }
-    }
-    else {
-        $fullSpec = $Spec
-    }
+    $fullSpec = Build-InstallSpec -Spec $Spec -Extras $Extras
 
     # add cupy as --with if suite3d is selected and CUDA is available
     $withArgs = @()
@@ -695,21 +687,27 @@ try:
     from importlib.metadata import version, distribution
     v = version('mbo_utilities')
     d = distribution('mbo_utilities')
-    # Check if installed from git
     direct_url = None
     try:
         import json
-        from pathlib import Path
-        dist_info = Path(d._path)
-        direct_url_file = dist_info / 'direct_url.json'
-        if direct_url_file.exists():
-            direct_url = json.loads(direct_url_file.read_text())
-    except: pass
+        du_files = [f for f in (d.files or []) if str(f).endswith('direct_url.json')]
+        if du_files:
+            du_path = d.locate_file(du_files[0])
+            if du_path.exists():
+                direct_url = json.loads(du_path.read_text())
+    except Exception:
+        pass
     if direct_url and 'vcs_info' in direct_url:
         vcs = direct_url['vcs_info']
         commit = vcs.get('commit_id', 'unknown')[:8]
         branch = vcs.get('requested_revision', 'unknown')
         print(f'{v}|git|{branch}|{commit}')
+    elif direct_url and direct_url.get('dir_info', {}).get('editable', False):
+        url = direct_url.get('url', '')
+        print(f'{v}|editable|{url}|')
+    elif direct_url:
+        url = direct_url.get('url', '')
+        print(f'{v}|local|{url}|')
     else:
         print(f'{v}|pypi||')
 except Exception as e:
@@ -729,6 +727,43 @@ except Exception as e:
     catch {}
 
     return $null
+}
+
+function Format-MboSourceLabel {
+    <#
+    .SYNOPSIS
+    Returns a display string for mbo_utilities install source.
+    #>
+    param([hashtable]$Info)
+
+    if (-not $Info) { return "" }
+
+    switch ($Info.Source) {
+        "git"      { return " (git: $($Info.Branch)@$($Info.Commit))" }
+        "editable" { return " (editable)" }
+        "local"    { return " (local)" }
+        "pypi"     { return " (PyPI)" }
+        default    { return "" }
+    }
+}
+
+function Build-InstallSpec {
+    <#
+    .SYNOPSIS
+    Build a pip/tool install spec string with extras.
+    #>
+    param(
+        [string]$Spec,
+        [string[]]$Extras = @()
+    )
+
+    if ($Extras.Count -eq 0) { return $Spec }
+
+    $extrasStr = "[" + ($Extras -join ',') + "]"
+    if ($Spec -match '^([^\s@]+)(\s*@\s*.*)$') {
+        return $matches[1] + $extrasStr + $matches[2]
+    }
+    return "$Spec$extrasStr"
 }
 
 function Install-DevEnvironment {
@@ -772,16 +807,16 @@ function Install-DevEnvironment {
                 if ($installedInfo) {
                     Write-Host "    mbo_utilities: " -NoNewline -ForegroundColor Gray
                     Write-Host "v$($installedInfo.Version)" -NoNewline -ForegroundColor Cyan
-                    if ($installedInfo.Source -eq "git") {
-                        Write-Host " (git: $($installedInfo.Branch)@$($installedInfo.Commit))" -ForegroundColor Gray
-                    } else {
-                        Write-Host " (PyPI)" -ForegroundColor Gray
-                    }
+                    Write-Host (Format-MboSourceLabel $installedInfo) -ForegroundColor Gray
                 } else {
                     Write-Host "    mbo_utilities: " -NoNewline -ForegroundColor Gray
                     Write-Host "not installed or error reading" -ForegroundColor Yellow
                 }
                 Write-Host "    Python: $venvPythonPath" -ForegroundColor Gray
+                Write-Host ""
+                $displaySpec = Build-InstallSpec -Spec $Spec -Extras $Extras
+                Write-Host "  Will install: " -NoNewline -ForegroundColor Gray
+                Write-Host $displaySpec -ForegroundColor White
                 Write-Host ""
                 Write-Host "  [1] Overwrite - Delete .venv and recreate" -ForegroundColor Cyan
                 Write-Host "  [2] Update    - Install/upgrade mbo_utilities in existing .venv" -ForegroundColor Cyan
@@ -885,13 +920,13 @@ function Install-DevEnvironment {
             if ($installedInfo) {
                 Write-Host "  Installed: " -NoNewline -ForegroundColor Gray
                 Write-Host "mbo_utilities v$($installedInfo.Version)" -NoNewline -ForegroundColor Cyan
-                if ($installedInfo.Source -eq "git") {
-                    Write-Host " (git: $($installedInfo.Branch)@$($installedInfo.Commit))" -ForegroundColor Gray
-                } else {
-                    Write-Host " (PyPI)" -ForegroundColor Gray
-                }
+                Write-Host (Format-MboSourceLabel $installedInfo) -ForegroundColor Gray
                 Write-Host ""
             }
+            $displaySpec = Build-InstallSpec -Spec $Spec -Extras $Extras
+            Write-Host "  Will install: " -NoNewline -ForegroundColor Gray
+            Write-Host $displaySpec -ForegroundColor White
+            Write-Host ""
             Write-Host "  [1] Overwrite - Delete and recreate" -ForegroundColor Cyan
             Write-Host "  [2] Update    - Install into existing" -ForegroundColor Cyan
             Write-Host "  [3] Skip      - Don't modify dev environment" -ForegroundColor Cyan
@@ -934,23 +969,7 @@ function Install-DevEnvironment {
         }
     }
 
-    # build spec with extras
-    # For git URLs: "mbo_utilities @ git+..." -> "mbo_utilities[extras] @ git+..."
-    # For PyPI: "mbo_utilities" -> "mbo_utilities[extras]"
-    if ($Extras.Count -gt 0) {
-        $extrasStr = "[" + ($Extras -join ',') + "]"
-        if ($Spec -match '^([^\s@]+)(\s*@\s*.*)$') {
-            # Git URL format: insert extras after package name, before @ URL
-            $fullSpec = $matches[1] + $extrasStr + $matches[2]
-        }
-        else {
-            # PyPI format: just append extras
-            $fullSpec = "$Spec$extrasStr"
-        }
-    }
-    else {
-        $fullSpec = $Spec
-    }
+    $fullSpec = Build-InstallSpec -Spec $Spec -Extras $Extras
 
     Write-Info "Installing mbo_utilities into environment..."
     Write-Info "  Spec: $fullSpec"
@@ -1225,34 +1244,24 @@ function Show-UsageInstructions {
     )
 
     Write-Host ""
-    Write-Host "Installation Complete" -ForegroundColor White
+    Write-Host "Installation Complete" -ForegroundColor Green
     Write-Host ""
 
     if ($CliInstalled) {
-        $binDir = Get-UvToolBinDir
-        Write-Host "  CLI Location:" -ForegroundColor Gray
-        Write-Host "    $binDir\mbo.exe" -ForegroundColor Cyan
+        Write-Host "  Launch:" -ForegroundColor Gray
+        Write-Host "    mbo" -ForegroundColor White
         Write-Host ""
-        Write-Host "  Usage:" -ForegroundColor Gray
-        Write-Host "    mbo                    # Open GUI" -ForegroundColor White
-        Write-Host "    mbo /path/to/data      # Open specific file" -ForegroundColor White
-        Write-Host "    mbo --help             # Show all commands" -ForegroundColor White
+        Write-Host "  Update:" -ForegroundColor Gray
+        Write-Host "    uv tool upgrade mbo_utilities" -ForegroundColor White
+        Write-Host ""
+        Write-Host "  Reinstall:" -ForegroundColor Gray
+        Write-Host "    uv tool install mbo_utilities --force" -ForegroundColor White
         Write-Host ""
     }
 
     if ($EnvPath) {
-        Write-Host "  Development Environment:" -ForegroundColor Gray
+        Write-Host "  Dev environment:" -ForegroundColor Gray
         Write-Host "    $EnvPath" -ForegroundColor Cyan
-        Write-Host ""
-        Write-Host "  Activate:" -ForegroundColor Gray
-        Write-Host "    $EnvPath\Scripts\activate" -ForegroundColor White
-        Write-Host ""
-        Write-Host "  Use in VSCode:" -ForegroundColor Gray
-        Write-Host "    Ctrl+Shift+P -> 'Python: Select Interpreter'" -ForegroundColor White
-        Write-Host "    Choose: $EnvPath\Scripts\python.exe" -ForegroundColor White
-        Write-Host ""
-        Write-Host "  Add packages:" -ForegroundColor Gray
-        Write-Host "    uv pip install --python `"$EnvPath\Scripts\python.exe`" <package>" -ForegroundColor White
         Write-Host ""
     }
 }


### PR DESCRIPTION
Make arrays TZCYX by default, always 5D with missing dimensions filled by singletons. No squeezing until absolutely needed, e.g. __getitem__ is only responsible for indexing